### PR TITLE
PT-748/PT-765: Update jenkins script to use latest pipelines DSL

### DIFF
--- a/demo/android/ci/buildReleaseStages.groovy
+++ b/demo/android/ci/buildReleaseStages.groovy
@@ -1,6 +1,6 @@
 def call(pipelineParams) {
 
-    ecsAgent(pipelineParams.mainAgent) {
+    withAgent(pipelineParams.mainAgent) {
         stage('Build') {
             checkout scm
             dir('demo/android') {

--- a/demo/android/ci/jenkinsfile
+++ b/demo/android/ci/jenkinsfile
@@ -2,8 +2,8 @@
 
 defaultPipeline {
     platform = 'android'
-    alphaStages = 'demo/android/ci/dummyStages.groovy'
-    buildStages = 'demo/android/ci/dummyStages.groovy'
-    prbStages = 'demo/android/ci/dummyStages.groovy'
-    buildReleaseStages = 'demo/android/ci/buildReleaseStages.groovy'
+    stages = [
+        'Build': 'demo/android/ci/dummyStages.groovy',
+        'BuildRelease': 'demo/android/ci/buildReleaseStages.groovy'
+    ]
 }


### PR DESCRIPTION
> JIRA ticket: [PT-765](https://glovoapp.atlassian.net/browse/PT-765)

# What does this PR do? 
The DSL from the pipeline library has changed in [`glovo-jenkins-mobile-pipelines/#2`](https://github.com/Glovo/glovo-jenkins-mobile-pipelines/pull/2).

# Implementation Considerations
- A `defaultPipeline` requires to provide a map of `stages` defining the workflow
- Consumers are required to provide the scripts defining the stages for `Build` and `BuildRelease`
- The `ecsAgent` DSL is now renamed to `withAgent`
- `Alpha` and `Prb` are not baked-in in the pipelines library anymore, we instead provide a way to define as many custom stages as needed and link to their jenkins scripts (more on this later)

# Has the solution been tested?
Tested that the workflow works on the testing jenkins instance for the demo app in this repo.