### PR TITLE
PT-748/PT-765: Use new stage definition DSL

### DIFF
--- a/demo/android/ci/jenkinsfile
+++ b/demo/android/ci/jenkinsfile
@@ -3,7 +3,7 @@
 mobilePipeline {
     platform = 'android'
     stages = [
-        'Build': 'demo/android/ci/dummyStages.groovy',
-        'BuildRelease': 'demo/android/ci/buildReleaseStages.groovy'
+        'Build': { stage = 'demo/android/ci/dummyStages.groovy' },
+        'BuildRelease': { stage = 'demo/android/ci/buildReleaseStages.groovy' }
     ]
 }


### PR DESCRIPTION
> JIRA ticket: [PT-765](https://glovoapp.atlassian.net/browse/PT-765)

# What does this PR do? 
After the changes in https://github.com/Glovo/glovo-jenkins-mobile-pipelines/pull/5 the DSL for defining stages has changed further.

# Implementation Considerations
Notable changes:
- there's no `defaultPipeline` anymore, we can just use `mobilePipeline` instead
- the definition of a stage takes a configuration closure allowing to define more than just the script to be executed for it, as defined in [`StageParams`](https://github.com/Glovo/glovo-jenkins-mobile-pipelines/blob/2104f73ba56e2cf804cb0293d5028f86a9b33479/src/com/glovoapp/pipeline/params/StageParams.groovy)

# Has the solution been tested?
Manually checked that the release workflow for the demo app works as expected.