### PR TITLE
PT-758/PT-833: Use HockeyApp Jenkins plugin to push Android builds to beta

### DIFF
--- a/demo/android/ci/buildReleaseStages.groovy
+++ b/demo/android/ci/buildReleaseStages.groovy
@@ -1,3 +1,9 @@
+static String readReleaseNotes() {
+    return """\
+        - Released on: ${new Date().toString()}
+        """.stripIndent()
+}
+
 def call(pipelineParams, stageConfig, stageParams) {
 
     withAgent(pipelineParams.mainAgent) {
@@ -7,6 +13,25 @@ def call(pipelineParams, stageConfig, stageParams) {
                 echo 'Start build'
                 sh './gradlew --no-daemon :app:assemble'
                 echo 'Build finished'
+                echo 'Pushing to HockeyApp'
+                withCredentials([string(credentialsId: 'hockey-app-token', variable: 'HOCKEY_API_TOKEN')]) {
+                    hockeyApp(
+                            applications: [
+                                    [
+                                            apiToken          : "$HOCKEY_API_TOKEN",
+                                            downloadAllowed   : true,
+                                            filePath          : 'app/build/outputs/apk/debug/app-debug.apk',
+                                            mandatory         : true,
+                                            notifyTeam        : true,
+                                            releaseNotesMethod: manual(releaseNotes: readReleaseNotes(), isMarkDown: true),
+                                            uploadMethod      : versionCreation(appId: 'e4bacf5c548547b0bf48a37b671b1bad')
+                                    ]
+                            ],
+                            baseUrl: '',
+                            debugMode: true,
+                            failGracefully: false
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
> JIRA ticket: [PT-833](https://glovoapp.atlassian.net/browse/PT-833)

# What does this PR do? 
We want to provide a solution to push builds to HockeyApp that is easy to integrate with our Jenkins Shared Pipeline without resorting to using other tools (ie: Fastlane).

# Implementation Considerations
We will be using this Jenkins plugin: https://wiki.jenkins.io/display/JENKINS/HockeyApp+Plugin. Please note that the project is marked as deprecated because HockeyApp will be shut down as service later this year in favor of Microsoft AppCenter. A replacement plugin is actively in the working to support the transition and we expect to be able to just use that when needed.

We are considering to streamline the setup of this plugin providing a DSL extension as part of our workflow pipeline shared library that will allow to setup the defaults used across Glovo. A follow-up ticket will take care of that once we identify better what actually makes sense for the release workflow.

# Has the solution been tested?
Manually tested that the `BuildReleaseStage` will also push a new build to HockeyApp for the entry identified by the specified `appId`.