### PR TITLE
PT-758/PT-903: Use githubRelease extension

### DIFF
--- a/demo/android/ci/buildReleaseStages.groovy
+++ b/demo/android/ci/buildReleaseStages.groovy
@@ -13,6 +13,21 @@ def call(pipelineParams, stageConfig, stageParams, input) {
                 sh './gradlew --no-daemon :app:assemble'
             }
         }
+        stage('Release to GitHub') {
+            withAuth.secretText('mr-archano-github-token') { githubToken ->
+                def version = "v$BRANCH_NAME" - 'release/' + "-RC$BUILD_NUMBER"
+                githubRelease {
+                    apiToken = githubToken
+                    repo = 'glovo/gradle-mobile-release-plugin'
+                    tag = version
+                    name = "Release $version"
+                    body = "Body for $version"
+                    isDraft = false
+                    asset('**/*.apk')
+                }
+            }
+
+        }
         stage('Deploy to HockeyApp') {
             withCredentials([string(credentialsId: 'hockey-app-token', variable: 'HOCKEY_API_TOKEN')]) {
                 hockeyApp(


### PR DESCRIPTION
> JIRA ticket: [PT-903](https://glovoapp.atlassian.net/browse/PT-903)

# What does this PR do? 
Adds an example of how to create a release in GitHub using the DSL extension from https://github.com/Glovo/glovo-jenkins-pipelines/pull/29

# Implementation Considerations
* Use new `githubRelease` extension providing an example of custom tagging logic
* Incidentally we are taking advantage of the `withAuth` utility introduced in https://github.com/Glovo/glovo-jenkins-pipelines/pull/27

# Has the solution been tested?
Manually tested that triggering the `BuildRelease` stage as part of the release workflow will yield a release in GitHub for the new release candidate