### PR TITLE
[GRO-5428] Remove agent node from jenkins pipeline config

### DIFF
--- a/ci/jenkinsfile
+++ b/ci/jenkinsfile
@@ -4,43 +4,45 @@ withAuth.secretText("ARTIFACTORY_PASSWORD") { password ->
     env.ANDROID_SDK_ROOT = '/opt/android-sdk/'
     env.ORG_GRADLE_PROJECT_artifactory_user = 'jenkins'
     env.ORG_GRADLE_PROJECT_artifactory_key = password
-
-    pipeline {
-        parameters {
-            booleanParam defaultValue: false, description: 'Perform the publication to artifactory', name: 'Publish'
+}
+pipeline {
+    parameters {
+        booleanParam defaultValue: false, description: 'Perform the publication to Artifactory', name: 'Publish'
+    }
+    agent {
+        node {
+            label 'mobile'
         }
-        agent {
-            node {
-                label 'mobile'
+    }
+    environment {
+        ANDROID_SDK_ROOT = '/opt/android-sdk/'
+    }
+    stages {
+        stage('Build plugins') {
+            steps {
+                sh "./gradlew --stacktrace clean build"
+            }
+            post {
+                always {
+                    junit "**/build/test-results/**/*.xml"
+                }
             }
         }
-        stages {
-            stage('Build plugins') {
-                steps {
+        stage('Build Demos') {
+            steps {
+                dir('demo/android') {
                     sh "./gradlew --stacktrace clean build"
                 }
-                post {
-                    always {
-                        junit "**/build/test-results/**/*.xml"
-                    }
+            }
+        }
+        stage('Publish SDK artifacts') {
+            when {
+                expression {
+                    params.Publish
                 }
             }
-            stage('Build Demos') {
-                steps {
-                    dir('demo/android') {
-                        sh "./gradlew --stacktrace clean build"
-                    }
-                }
-            }
-            stage('Publish SDK artifacts') {
-                when {
-                    expression {
-                        params.Publish
-                    }
-                }
-                steps {
-                    sh "./gradlew --stacktrace artifactoryPublish"
-                }
+            steps {
+                sh "./gradlew --stacktrace artifactoryPublish"
             }
         }
     }


### PR DESCRIPTION
> JIRA ticket: [GRO-5428](https://glovoapp.atlassian.net/browse/GRO-5428)

Merging [reconfig PR](https://github.com/Glovo/gradle-mobile-release-plugin/pull/16) caused error running [pipelines](https://jenkins-master.glovoapp.com/job/GradleMobileReleasePlugin/job/develop/15/console). This problem emerged only when merged, pipeline succeeded [before merge](https://jenkins-master.glovoapp.com/job/GradleMobileReleasePlugin/view/change-requests/job/PR-16/)

# What does this PR do? 
To declare env variables for Jenkins
```
env.ORG_GRADLE_PROJECT_artifactory_user
env.ORG_GRADLE_PROJECT_artifactory_key 
```
`library 'glovo-jenkins-pipelines@v3.4.3'` was introduced in previous PR. Configuring `pipeline` inside `passwordwithAuth.secretText("ARTIFACTORY_PASSWORD")` block, similiar to Android Customer Jenkinsfile resulted in error: [No such DSL method 'stages' found among steps ](https://jenkins-master.glovoapp.com/blue/organizations/jenkins/GradleMobileReleasePlugin/detail/PR-17/2/pipeline)

This was resolved by moving `pipeline` declaration out of `passwordwithAuth.secretText` block.

# Implementation Considerations
* Provide a brief explanation of any relevant high level implementation considerations.
* This can contain details that you consider it important for reviewers to know before examining the actual code

# Has the solution been tested?
* If yes: provide a brief summary of what has been tested
* Otherwise: provide an explanation of why the solution has not been tested
