### PR TITLE
Gro 5428/artifactory publication issue

### DIFF
--- a/ci/jenkinsfile
+++ b/ci/jenkinsfile
@@ -21,7 +21,6 @@ pipeline {
         stage('Build plugins') {
             steps {
                 sh "./gradlew --stacktrace clean build"
-                sh "./gradlew --stacktrace artifactoryPublish --debug"
             }
             post {
                 always {
@@ -43,7 +42,7 @@ pipeline {
                 }
             }
             steps {
-                sh "./gradlew --stacktrace artifactoryPublish"
+                sh "./gradlew --stacktrace artifactoryPublish --debug"
             }
         }
     }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -2,6 +2,7 @@ static void configurePublishing(Project project, String id) {
     project.with {
         apply plugin: 'maven-publish'
         apply plugin: 'com.jfrog.artifactory'
+        // Skip for root project
         artifactoryPublish.skip = true
 
         plugins.withId('java') {
@@ -19,7 +20,6 @@ static void configurePublishing(Project project, String id) {
                     defaults {
                         publications('mavenJava')
                         publishArtifacts true
-                        version = "0.0.1"
                     }
                 }
                 resolve {


### PR DESCRIPTION
> JIRA ticket: [GRO-5428](https://glovoapp.atlassian.net/browse/GRO-5428)

# What does this PR do? 
It turned out that for multimodule projects Artifactory needs some more configuration.
In the process, `artifactoryPublish` task was set to run on PRs, so the configuration can be checked: https://jenkins-master.glovoapp.com/blue/organizations/jenkins/GradleMobileReleasePlugin/detail/PR-18/3/pipeline/20

Some links that helped me with this:
https://stackoverflow.com/a/58136027/7195804
https://github.com/jfrog/project-examples/tree/master/gradle-examples/gradle-android-example
https://stackoverflow.com/questions/35851251/gradle-artifactory-plugin-how-to-publish-artifacts-from-multiple-modules-in-a
https://github.com/jfrog/build-info/issues/145

# Implementation Considerations
* Provide a brief explanation of any relevant high level implementation considerations.
* This can contain details that you consider it important for reviewers to know before examining the actual code

# Has the solution been tested?
* If yes: provide a brief summary of what has been tested
* Otherwise: provide an explanation of why the solution has not been tested
