### PR TITLE
[Tech] Update Android Gradle Plugin to version 4.1.1

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -16,7 +16,7 @@ gradlePlugin {
 }
 
 dependencies {
-    implementation("com.android.tools.build:gradle:4.0.1")
+    implementation("com.android.tools.build:gradle:4.1.1")
 
     testImplementation(gradleTestKit())
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.7.0")


### PR DESCRIPTION

## What does this PR do? 
* update Android Gradle Plugin to version `4.1.1`

## Implementation Considerations
[Android Gradle Plugin: release notes](https://developer.android.com/studio/releases/gradle-plugin#4-1-0)


