### PR TITLE
Patch/failed publications

### DIFF
--- a/plugin/src/main/kotlin/com/glovoapp/versioning/ExperimentalVersionPlugin.kt
+++ b/plugin/src/main/kotlin/com/glovoapp/versioning/ExperimentalVersionPlugin.kt
@@ -70,10 +70,12 @@ internal class ExperimentalVersionPlugin : Plugin<Project> {
                 .let { uuids.getOrPut(it) { UUID.randomUUID() } }
         }
 
+        val buildIdDir by lazy { file("$buildDir/$REPORT_DIR/${buildId}").apply { deleteOnExit() } }
+
         // collects all publications done to MavenLocal in a file (to support included builds)
         val publishToMavenLocalTasks = hashSetOf<TaskProvider<*>>()
         val collectPublications = tasks.register("collectMavenLocalPublications") {
-            val file = file("$buildDir/$REPORT_DIR/${buildId}/${project.name}.txt")
+            val file = file("$buildIdDir/${project.name}.txt").apply { deleteOnExit() }
 
             outputs.file(file)
             outputs.upToDateWhen { false }


### PR DESCRIPTION
# What does this PR do? 
- Fixes `experimentalVersion` run twice if it's used in `includedBuilds`
- Adds a notification if a publication was not published (because an error or skipped)
