### PR TITLE
[MOB-916] Fixed AGP `7.1.2` too late to change issue

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin-android/build.gradle.kts
+++ b/plugin-android/build.gradle.kts
@@ -10,7 +10,7 @@ base.archivesName.set("gradle-android-versioning-plugin")
 
 dependencies {
     api(project(":plugin"))
-    implementation("com.android.tools.build:gradle:7.0.2")
+    implementation("com.android.tools.build:gradle:7.1.2")
     testImplementation(testFixtures(project(":plugin")))
 }
 

--- a/plugin-android/src/main/kotlin/com/glovoapp/versioning/AndroidVersioningPlugin.kt
+++ b/plugin-android/src/main/kotlin/com/glovoapp/versioning/AndroidVersioningPlugin.kt
@@ -1,5 +1,6 @@
 package com.glovoapp.versioning
 
+import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.api.AndroidBasePlugin
 import com.glovoapp.versioning.SemanticVersioningPlugin.Companion.GROUP
@@ -11,8 +12,10 @@ import org.gradle.api.Project
 import org.gradle.api.internal.plugins.DslObject
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
+import kotlin.reflect.KMutableProperty
 
 class AndroidVersioningPlugin : Plugin<Project> {
 
@@ -24,58 +27,83 @@ class AndroidVersioningPlugin : Plugin<Project> {
                 .extensions.create<AndroidVersioningExtension>("versioning")
         }
 
-        plugins.withType<AndroidBasePlugin> {
-            @Suppress("UNUSED_EXPRESSION")
-            extension // early init so the extension will be available for scripting under `android.versioning`
-        }
-
         afterEvaluate {
             check(plugins.hasPlugin(AndroidBasePlugin::class.java)) {
                 "${this@AndroidVersioningPlugin::class.java} requires an `android` to be applied"
             }
+        }
 
-            val androidVersion = extension.version.get()
+        plugins.withType<AndroidBasePlugin> {
+            @Suppress("UNUSED_EXPRESSION")
+            extension // early init so the extension will be available for scripting under `android.versioning`
 
-            val incrementVersionCodeTask = androidVersion.code?.let {
-                tasks.register<IncrementNumericVersionTask>("incrementVersionCode") {
-                    group = GROUP
-                    description = "Increments the project's versionCode by given `amount`"
-                    version.value(it).disallowChanges()
-                }
-            }
+            extensions
+                .getByName<AndroidComponentsExtension<*, *, *>>("androidComponents")
+                .finalizeDsl {
+                    val androidVersion = extension.version.get()
 
-            val incrementVersionNameTask = androidVersion.name?.let {
-                tasks.register<IncrementSemanticVersionTask>("incrementVersionName") {
-                    group = GROUP
-                    description = "Increments the project's versionName by given `increment`"
-                    version.value(it).disallowChanges()
-                }
-            }
+                    val incrementVersionCodeTask = androidVersion.code?.let {
+                        tasks.register<IncrementNumericVersionTask>("incrementVersionCode") {
+                            group = GROUP
+                            description = "Increments the project's versionCode by given `amount`"
+                            version.value(it).disallowChanges()
+                        }
+                    }
 
-            configure<BaseExtension> {
-                defaultConfig {
-                    androidVersion.code?.onChanged { versionCode = it }
-                    androidVersion.name?.onChanged { versionName = it.toString(); }
-                }
-            }
+                    val incrementVersionNameTask = androidVersion.name?.let {
+                        tasks.register<IncrementSemanticVersionTask>("incrementVersionName") {
+                            group = GROUP
+                            description =
+                                "Increments the project's versionName by given `increment`"
+                            version.value(it).disallowChanges()
+                        }
+                    }
 
-            // ensures these task are run (if present in the graph) before any Android build task
-            tasks.named("preBuild") {
-                doFirst {
-                    checkNotNull(androidVersion.code ?: androidVersion.name) {
-                        "Please provide at least one of '${extension.versionCodeProperty.get()}' or " +
-                                "'${extension.versionCodeProperty.get()}' properties on " +
-                                "`${extension.propertiesFile.get()}`"
+                    configure<BaseExtension> {
+                        defaultConfig {
+                            fun <Type : Any, PropType> PersistedVersion<Type>.bind(
+                                property: KMutableProperty<PropType?>,
+                                transform: (Type) -> PropType
+                            ) {
+                                val propValue = transform(value)
+
+                                property.setter.call(propValue)
+
+                                onChanged {
+                                    val current = property.getter.call()
+
+                                    if (propValue != current) {
+                                        error("""
+                                        $name has changed but not reflected into Android build:
+                                        before: $current
+                                        after: $propValue
+                                        """.trimIndent())
+                                    }
+                                }
+                            }
+
+                            androidVersion.code?.bind(::versionCode) { it }
+                            androidVersion.name?.bind(::versionName) { it.toString() }
+                        }
+                    }
+
+                    // ensures these task are run (if present in the graph) before any Android build task
+                    tasks.named("preBuild") {
+                        doFirst {
+                            checkNotNull(androidVersion.code ?: androidVersion.name) {
+                                "Please provide at least one of '${extension.versionCodeProperty.get()}' or " +
+                                        "'${extension.versionCodeProperty.get()}' properties on " +
+                                        "`${extension.propertiesFile.get()}`"
+                            }
+                        }
+                        shouldRunAfter(
+                            *listOfNotNull(
+                                incrementVersionCodeTask,
+                                incrementVersionNameTask
+                            ).toTypedArray()
+                        )
                     }
                 }
-                shouldRunAfter(
-                    *listOfNotNull(
-                        incrementVersionCodeTask,
-                        incrementVersionNameTask
-                    ).toTypedArray()
-                )
-            }
         }
     }
-
 }

--- a/plugin/src/main/kotlin/com/glovoapp/versioning/SemanticVersioningPlugin.kt
+++ b/plugin/src/main/kotlin/com/glovoapp/versioning/SemanticVersioningPlugin.kt
@@ -13,7 +13,7 @@ class SemanticVersioningPlugin : Plugin<Project> {
     companion object {
         const val GROUP = "versioning"
         const val TASK_NAME = "incrementSemanticVersion"
-        val minimumGradleVersion = SemanticVersion(7, 1)
+        val minimumGradleVersion = SemanticVersion(7, 2)
 
         fun Project.ensureGradleVersion() = check(gradle.gradleVersion.toVersion() >= minimumGradleVersion) {
             "This plugin requires at least Gradle $minimumGradleVersion"


### PR DESCRIPTION
> JIRA ticket: https://glovoapp.atlassian.net/browse/MOB-916

# What does this PR do? 
* Fix the integration with AGP plugin by removing the `afterEvaluate` clouse to `finalizeDSL`

Since `AGP 7.1.2`, any changes on Android's DSL setup, like `versionCode` and `versionName` are forgiven after the evaluation phase.
Now, instead of waiting for the end of the evaluation phase to compute the version (we need this to give the chance to the user to configure the `android.versioning` closure), we are hooking on the new `androidComponents.finalizeDsl` method which is call while the evaluation phase, but before `androidVariants` are realized, where is still legal to set `versionCode` and `versionName`.