### PR TITLE
[IR-1989] Add linting job in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,13 @@ on:
       - master
 
 jobs:
+  lint:
+    name: Linting
+    uses: Glovo/remote-gh-actions/.github/workflows/ci-lint.yaml@v3 
+    with:
+      WORKFLOW_VERSION: v3
+      MANIFEST_FILE_NAME: image_attributes.yaml           
+    secrets: inherit
   Build:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
What? <br /> We add a `Linting` job in build.yaml workflow.  <br /> <br />  Why is it important? <br />  This update introduces a Linting job into the build.yaml workflow. The purpose of this addition is to enhance the overall quality and reliability of your Kubernetes configuration. Previously, there were no checks in place for potential misconfigurations, allowing unrestricted configuration values for your services. The new linting action aims to address this by parsing and verifying domain names for possible errors, such as typos or incorrect domains based on the environment. <br /> <br /> What we expect <br /> Upon merging this change, a Linting step will be integrated into your CI configuration. If there are any misconfigurations, they will be displayed in the GitHub output once the action is completed. Please pay attention to the GitHub output after this change is merged, as it will provide insights into any potential misconfigurations detected during the linting process. This step is designed to improve the development experience and minimize deployment issues. Thank you!

[_Created by Sourcegraph batch change `DimKanoute/add-linting-job-to-ci`._](https://glovo.sourcegraph.com/users/DimKanoute/batch-changes/add-linting-job-to-ci)